### PR TITLE
Add Solarvolt CLI with storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,16 @@
 Cazye77R/Cazye77R is a ✨ special ✨ repository because its `README.md` (this file) appears on your GitHub profile.
 You can click the Preview link to take a look at your changes.
 --->
+
+## Solarvolt App
+
+Solarvolt is a small command-line application with a simple storage function. It lets you save key/value pairs to a JSON file and list them later.
+
+### Usage
+
+```bash
+python solarvolt.py add <key> <value>  # Save a new entry
+python solarvolt.py list               # Show all saved entries
+```
+
+The saved data will be stored in `solarvolt_data.json` in the same directory.

--- a/solarvolt.py
+++ b/solarvolt.py
@@ -1,0 +1,62 @@
+import json
+import os
+import sys
+
+STORAGE_FILE = 'solarvolt_data.json'
+
+
+def load_data():
+    if os.path.exists(STORAGE_FILE):
+        with open(STORAGE_FILE, 'r') as f:
+            try:
+                return json.load(f)
+            except json.JSONDecodeError:
+                return {}
+    return {}
+
+
+def save_data(data):
+    with open(STORAGE_FILE, 'w') as f:
+        json.dump(data, f, indent=2)
+
+
+def add_entry(key, value):
+    data = load_data()
+    data[key] = value
+    save_data(data)
+
+
+def list_entries():
+    data = load_data()
+    if not data:
+        print('No entries saved.')
+    else:
+        for key, value in data.items():
+            print(f"{key}: {value}")
+
+
+def usage():
+    print('Usage: python solarvolt.py add <key> <value>')
+    print('       python solarvolt.py list')
+
+
+def main():
+    if len(sys.argv) < 2:
+        usage()
+        return
+
+    command = sys.argv[1]
+
+    if command == 'add' and len(sys.argv) >= 4:
+        key = sys.argv[2]
+        value = ' '.join(sys.argv[3:])
+        add_entry(key, value)
+        print(f"Saved {key}: {value}")
+    elif command == 'list':
+        list_entries()
+    else:
+        usage()
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add `solarvolt.py` implementing a simple JSON-based store
- document how to use Solarvolt in the README

## Testing
- `python solarvolt.py list`
- `python solarvolt.py add testkey "Hello world" && python solarvolt.py list`


------
https://chatgpt.com/codex/tasks/task_e_688237d206cc832c903ecb2bd4989aa2