### PR TITLE
Add LSTM training pipeline for stock returns

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,43 @@
-- 👋 Hi, I’m @Cazye77R
-- 👀 I’m interested in ...
-- 🌱 I’m currently learning Python
-- 💞️ I’m looking to collaborate on ...
-- 📫 How to reach me ...
-- ⚡ Fun fact: ...
+# Stock Return Forecasting Model
 
-<!---
-Cazye77R/Cazye77R is a ✨ special ✨ repository because its `README.md` (this file) appears on your GitHub profile.
-You can click the Preview link to take a look at your changes.
---->
+Dieses Repository enthält ein einfaches, trainingsfähiges KI-Modell, das auf historischen Aktienkursbewegungen basiert. Es nutzt ein LSTM, um aus vergangenen Renditefenstern die nächste Rendite abzuleiten und kann auf beliebige Kurs-CSV-Dateien angewendet werden.
+
+## Funktionsumfang
+- CSV-Einlesung und Bereinigung (Sortierung nach Datum, Prozentänderungen, optionale Normalisierung).
+- Erzeugung von Sequenz-Datensätzen beliebiger Fensterlänge.
+- LSTM-Modell mit LayerNorm, Dropout und frei konfigurierbarer Hidden-Size/Layer-Anzahl.
+- Trainings-Skript mit Train/Val-Split, Loss-Reporting und Speicherung der Gewichte.
+
+## Installation
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+## Datenerwartung
+Eine CSV-Datei mit mindestens zwei Spalten:
+- `date`: Zeitstempel oder Datum (wird per `pandas` geparst)
+- `close`: Schlusskurs oder Preiswert
+
+Die Reihenfolge der Zeilen ist egal, das Skript sortiert automatisch nach Datum.
+
+## Training starten
+```bash
+python -m stock_model.train path/zum/daten.csv \
+  --window 60 \
+  --batch-size 128 \
+  --epochs 30 \
+  --lr 5e-4 \
+  --hidden-size 256 \
+  --layers 2 \
+  --dropout 0.2 \
+  --train-ratio 0.85 \
+  --output artifacts
+```
+Standardwerte sind im Skript hinterlegt, sodass Sie optional nur den CSV-Pfad angeben müssen.
+
+## Ergebnisse
+Nach dem Training wird ein Checkpoint unter `artifacts/return_lstm.pt` gespeichert, der sowohl die Modellgewichte als auch die wichtigsten Hyperparameter enthält. Dieses Format kann mit PyTorch geladen und für Inferenz oder weiteres Feintuning verwendet werden.
+
+Viel Erfolg beim Experimentieren mit Ihren Kursdaten!

--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ Eine CSV-Datei mit mindestens zwei Spalten:
 - `date`: Zeitstempel oder Datum (wird per `pandas` geparst)
 - `close`: Schlusskurs oder Preiswert
 
-Die Reihenfolge der Zeilen ist egal, das Skript sortiert automatisch nach Datum.
+Die Reihenfolge der Zeilen ist egal, das Skript sortiert automatisch nach Datum. Alternativ können öffentliche Kursdaten direk
+t mit dem Trainingsskript heruntergeladen werden.
 
 ## Training starten
 ```bash
@@ -36,6 +37,19 @@ python -m stock_model.train path/zum/daten.csv \
   --output artifacts
 ```
 Standardwerte sind im Skript hinterlegt, sodass Sie optional nur den CSV-Pfad angeben müssen.
+
+### Direktes Laden öffentlicher Kurse
+Über Yahoo Finance lassen sich Daten ohne separate CSV laden. Beispiel für den S&P 500 ETF (SPY) mit täglichen Daten seit 2020:
+
+```bash
+python -m stock_model.train \
+  --ticker SPY \
+  --start 2020-01-01 \
+  --interval 1d \
+  --epochs 15
+```
+
+Der gleiche Befehl kann mit Intraday-Intervallen (z.B. `1h`) oder benutzerdefinierten Zeiträumen genutzt werden.
 
 ## Ergebnisse
 Nach dem Training wird ein Checkpoint unter `artifacts/return_lstm.pt` gespeichert, der sowohl die Modellgewichte als auch die wichtigsten Hyperparameter enthält. Dieses Format kann mit PyTorch geladen und für Inferenz oder weiteres Feintuning verwendet werden.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+pandas>=2.0
+numpy>=1.24
+torch>=2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pandas>=2.0
 numpy>=1.24
 torch>=2.0
+yfinance>=0.2

--- a/stock_model/data.py
+++ b/stock_model/data.py
@@ -1,0 +1,73 @@
+"""Utilities for loading and preparing stock price data for sequence models."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Tuple
+
+import numpy as np
+import pandas as pd
+import torch
+from torch.utils.data import Dataset
+
+
+@dataclass
+class PriceData:
+    """Container for price data and derived returns."""
+
+    prices: np.ndarray
+    returns: np.ndarray
+
+
+def load_prices(
+    csv_path: Path | str,
+    date_col: str = "date",
+    price_col: str = "close",
+    normalize: bool = True,
+) -> PriceData:
+    """Load stock prices from a CSV file.
+
+    The CSV must include a date column (parseable by pandas) and a price column.
+    Data are sorted by date to ensure chronological order. Returns are computed as
+    percentage change, optionally normalized to zero mean and unit variance.
+    """
+
+    csv_path = Path(csv_path)
+    df = pd.read_csv(csv_path)
+    df[date_col] = pd.to_datetime(df[date_col])
+    df = df.sort_values(date_col)
+
+    prices = df[price_col].astype(float).to_numpy()
+    returns = np.diff(prices) / prices[:-1]
+
+    if normalize:
+        mean = returns.mean()
+        std = returns.std() or 1.0
+        returns = (returns - mean) / std
+
+    return PriceData(prices=prices, returns=returns)
+
+
+class PriceWindowDataset(Dataset[Tuple[torch.Tensor, torch.Tensor]]):
+    """Sequence dataset that predicts the next return from previous returns."""
+
+    def __init__(self, returns: Iterable[float], window: int = 30) -> None:
+        values = np.array(list(returns), dtype=np.float32)
+        if len(values) <= window:
+            raise ValueError("Not enough data to build any windows")
+        self.features = []
+        self.targets = []
+        for start in range(len(values) - window):
+            end = start + window
+            self.features.append(values[start:end])
+            self.targets.append(values[end])
+        self.features = np.stack(self.features)
+        self.targets = np.stack(self.targets)
+
+    def __len__(self) -> int:  # noqa: D401
+        return len(self.features)
+
+    def __getitem__(self, idx: int) -> Tuple[torch.Tensor, torch.Tensor]:  # noqa: D401
+        feature = torch.from_numpy(self.features[idx]).unsqueeze(-1)
+        target = torch.tensor(self.targets[idx], dtype=torch.float32)
+        return feature, target

--- a/stock_model/data.py
+++ b/stock_model/data.py
@@ -10,6 +10,8 @@ import pandas as pd
 import torch
 from torch.utils.data import Dataset
 
+import yfinance as yf
+
 
 @dataclass
 class PriceData:
@@ -17,6 +19,15 @@ class PriceData:
 
     prices: np.ndarray
     returns: np.ndarray
+
+
+def _compute_returns(prices: np.ndarray, normalize: bool) -> np.ndarray:
+    returns = np.diff(prices) / prices[:-1]
+    if normalize:
+        mean = returns.mean()
+        std = returns.std() or 1.0
+        returns = (returns - mean) / std
+    return returns
 
 
 def load_prices(
@@ -38,12 +49,37 @@ def load_prices(
     df = df.sort_values(date_col)
 
     prices = df[price_col].astype(float).to_numpy()
-    returns = np.diff(prices) / prices[:-1]
+    returns = _compute_returns(prices, normalize)
 
-    if normalize:
-        mean = returns.mean()
-        std = returns.std() or 1.0
-        returns = (returns - mean) / std
+    return PriceData(prices=prices, returns=returns)
+
+
+def fetch_prices(
+    ticker: str,
+    start: str | None = None,
+    end: str | None = None,
+    interval: str = "1d",
+    normalize: bool = True,
+) -> PriceData:
+    """Download public price data for a ticker using Yahoo Finance.
+
+    Args:
+        ticker: Symbol to download.
+        start: Optional ISO date (YYYY-MM-DD) for the first observation.
+        end: Optional ISO date (YYYY-MM-DD) for the last observation (exclusive).
+        interval: Sampling frequency supported by Yahoo Finance (e.g. "1d", "1h").
+        normalize: Whether to standardize returns.
+
+    Raises:
+        ValueError: If no data is returned for the ticker.
+    """
+
+    df = yf.download(ticker, start=start, end=end, interval=interval, progress=False)
+    if df.empty:
+        raise ValueError(f"No data returned for ticker '{ticker}'")
+
+    prices = df["Close"].astype(float).to_numpy()
+    returns = _compute_returns(prices, normalize)
 
     return PriceData(prices=prices, returns=returns)
 

--- a/stock_model/model.py
+++ b/stock_model/model.py
@@ -1,0 +1,38 @@
+"""Neural network model definitions for forecasting returns."""
+from __future__ import annotations
+
+import torch
+from torch import nn
+
+
+class ReturnLSTM(nn.Module):
+    """Predicts the next return based on a window of past returns."""
+
+    def __init__(
+        self,
+        input_dim: int = 1,
+        hidden_size: int = 64,
+        num_layers: int = 2,
+        dropout: float = 0.1,
+    ) -> None:
+        super().__init__()
+        self.lstm = nn.LSTM(
+            input_size=input_dim,
+            hidden_size=hidden_size,
+            num_layers=num_layers,
+            batch_first=True,
+            dropout=dropout if num_layers > 1 else 0.0,
+        )
+        self.head = nn.Sequential(
+            nn.LayerNorm(hidden_size),
+            nn.Linear(hidden_size, hidden_size // 2),
+            nn.ReLU(),
+            nn.Linear(hidden_size // 2, 1),
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:  # noqa: D401
+        # x: [batch, seq, features]
+        output, _ = self.lstm(x)
+        last_hidden = output[:, -1, :]
+        prediction = self.head(last_hidden).squeeze(-1)
+        return prediction

--- a/stock_model/train.py
+++ b/stock_model/train.py
@@ -1,0 +1,126 @@
+"""Training script for the return forecasting model."""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Tuple
+
+import torch
+from torch.utils.data import DataLoader, random_split
+
+from .data import PriceWindowDataset, load_prices
+from .model import ReturnLSTM
+
+
+def split_dataset(dataset: PriceWindowDataset, train_ratio: float) -> Tuple[PriceWindowDataset, PriceWindowDataset]:
+    train_len = int(len(dataset) * train_ratio)
+    val_len = len(dataset) - train_len
+    return random_split(dataset, [train_len, val_len], generator=torch.Generator().manual_seed(42))
+
+
+def train(
+    csv_path: Path,
+    output_dir: Path,
+    window: int = 30,
+    batch_size: int = 64,
+    epochs: int = 20,
+    lr: float = 1e-3,
+    hidden_size: int = 128,
+    num_layers: int = 2,
+    dropout: float = 0.1,
+    train_ratio: float = 0.8,
+    device: str | None = None,
+) -> None:
+    data = load_prices(csv_path)
+    dataset = PriceWindowDataset(data.returns, window=window)
+    train_set, val_set = split_dataset(dataset, train_ratio)
+
+    train_loader = DataLoader(train_set, batch_size=batch_size, shuffle=True)
+    val_loader = DataLoader(val_set, batch_size=batch_size)
+
+    model = ReturnLSTM(hidden_size=hidden_size, num_layers=num_layers, dropout=dropout)
+    optimizer = torch.optim.Adam(model.parameters(), lr=lr)
+    criterion = torch.nn.MSELoss()
+
+    model_device = device or ("cuda" if torch.cuda.is_available() else "cpu")
+    model.to(model_device)
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    for epoch in range(1, epochs + 1):
+        model.train()
+        total_loss = 0.0
+        for features, target in train_loader:
+            features, target = features.to(model_device), target.to(model_device)
+            optimizer.zero_grad()
+            preds = model(features)
+            loss = criterion(preds, target)
+            loss.backward()
+            optimizer.step()
+            total_loss += loss.item() * features.size(0)
+        train_loss = total_loss / len(train_loader.dataset)
+
+        model.eval()
+        val_loss = 0.0
+        with torch.no_grad():
+            for features, target in val_loader:
+                features, target = features.to(model_device), target.to(model_device)
+                preds = model(features)
+                loss = criterion(preds, target)
+                val_loss += loss.item() * features.size(0)
+        val_loss = val_loss / len(val_loader.dataset)
+
+        print(f"Epoch {epoch:03d} | train_loss={train_loss:.6f} | val_loss={val_loss:.6f}")
+
+    model_path = output_dir / "return_lstm.pt"
+    torch.save(
+        {
+            "model_state_dict": model.state_dict(),
+            "hyperparameters": {
+                "window": window,
+                "hidden_size": hidden_size,
+                "num_layers": num_layers,
+                "dropout": dropout,
+                "train_ratio": train_ratio,
+            },
+        },
+        model_path,
+    )
+    print(f"Saved model to {model_path}")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("csv_path", type=Path, help="Path to CSV file containing prices")
+    parser.add_argument("--output", type=Path, default=Path("artifacts"), help="Directory to save model checkpoints")
+    parser.add_argument("--window", type=int, default=30, help="Number of past returns per sample")
+    parser.add_argument("--batch-size", type=int, default=64, help="Training batch size")
+    parser.add_argument("--epochs", type=int, default=20, help="Number of training epochs")
+    parser.add_argument("--lr", type=float, default=1e-3, help="Learning rate")
+    parser.add_argument("--hidden-size", type=int, default=128, help="LSTM hidden size")
+    parser.add_argument("--layers", type=int, default=2, help="Number of LSTM layers")
+    parser.add_argument("--dropout", type=float, default=0.1, help="Dropout between LSTM layers")
+    parser.add_argument("--train-ratio", type=float, default=0.8, help="Ratio of samples for training")
+    parser.add_argument("--device", type=str, default=None, help="Optional device override (cpu or cuda)")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    train(
+        csv_path=args.csv_path,
+        output_dir=args.output,
+        window=args.window,
+        batch_size=args.batch_size,
+        epochs=args.epochs,
+        lr=args.lr,
+        hidden_size=args.hidden_size,
+        num_layers=args.layers,
+        dropout=args.dropout,
+        train_ratio=args.train_ratio,
+        device=args.device,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/stock_model/train.py
+++ b/stock_model/train.py
@@ -8,7 +8,7 @@ from typing import Tuple
 import torch
 from torch.utils.data import DataLoader, random_split
 
-from .data import PriceWindowDataset, load_prices
+from .data import PriceWindowDataset, fetch_prices, load_prices
 from .model import ReturnLSTM
 
 
@@ -19,7 +19,7 @@ def split_dataset(dataset: PriceWindowDataset, train_ratio: float) -> Tuple[Pric
 
 
 def train(
-    csv_path: Path,
+    csv_path: Path | None,
     output_dir: Path,
     window: int = 30,
     batch_size: int = 64,
@@ -30,8 +30,17 @@ def train(
     dropout: float = 0.1,
     train_ratio: float = 0.8,
     device: str | None = None,
+    ticker: str | None = None,
+    start: str | None = None,
+    end: str | None = None,
+    interval: str = "1d",
 ) -> None:
-    data = load_prices(csv_path)
+    if ticker:
+        data = fetch_prices(ticker, start=start, end=end, interval=interval)
+    elif csv_path is not None:
+        data = load_prices(csv_path)
+    else:
+        raise ValueError("Either ticker or csv_path must be provided")
     dataset = PriceWindowDataset(data.returns, window=window)
     train_set, val_set = split_dataset(dataset, train_ratio)
 
@@ -91,7 +100,11 @@ def train(
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("csv_path", type=Path, help="Path to CSV file containing prices")
+    parser.add_argument("csv_path", nargs="?", type=Path, help="Optional path to CSV file containing prices")
+    parser.add_argument("--ticker", type=str, help="Download public data for this ticker via Yahoo Finance")
+    parser.add_argument("--start", type=str, help="Optional ISO date (YYYY-MM-DD) for the first observation")
+    parser.add_argument("--end", type=str, help="Optional ISO date (YYYY-MM-DD) for the last observation (exclusive)")
+    parser.add_argument("--interval", type=str, default="1d", help="Sampling interval accepted by Yahoo Finance, e.g. 1d, 1h")
     parser.add_argument("--output", type=Path, default=Path("artifacts"), help="Directory to save model checkpoints")
     parser.add_argument("--window", type=int, default=30, help="Number of past returns per sample")
     parser.add_argument("--batch-size", type=int, default=64, help="Training batch size")
@@ -119,6 +132,10 @@ def main() -> None:
         dropout=args.dropout,
         train_ratio=args.train_ratio,
         device=args.device,
+        ticker=args.ticker,
+        start=args.start,
+        end=args.end,
+        interval=args.interval,
     )
 
 


### PR DESCRIPTION
## Summary
- add stock data loader and windowed dataset builder for return forecasting
- implement configurable LSTM model and training loop with checkpoint saving
- document setup and training instructions and declare Python dependencies

## Testing
- python -m compileall stock_model


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69261a7d1948832c8c465691060ca155)