### PR TITLE
Add dark-mode Streamlit forecaster UI

### DIFF
--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -1,0 +1,6 @@
+[theme]
+base = "dark"
+primaryColor = "#22d3ee"
+backgroundColor = "#0b1220"
+secondaryBackgroundColor = "#0f172a"
+textColor = "#e5e7eb"

--- a/README.md
+++ b/README.md
@@ -1,11 +1,56 @@
-- 👋 Hi, I’m @Cazye77R
-- 👀 I’m interested in ...
-- 🌱 I’m currently learning Python
-- 💞️ I’m looking to collaborate on ...
-- 📫 How to reach me ...
-- ⚡ Fun fact: ...
+# Stock Return Forecasting Model
 
-<!---
-Cazye77R/Cazye77R is a ✨ special ✨ repository because its `README.md` (this file) appears on your GitHub profile.
-You can click the Preview link to take a look at your changes.
---->
+Dieses Repository enthält ein einfaches, trainingsfähiges KI-Modell, das auf historischen Aktienkursbewegungen basiert. Es nutzt ein LSTM, um aus vergangenen Renditefenstern die nächste Rendite abzuleiten und kann auf beliebige Kurs-CSV-Dateien angewendet werden.
+
+## Funktionsumfang
+- CSV-Einlesung und Bereinigung (Sortierung nach Datum, Prozentänderungen, optionale Normalisierung).
+- Erzeugung von Sequenz-Datensätzen beliebiger Fensterlänge.
+- LSTM-Modell mit LayerNorm, Dropout und frei konfigurierbarer Hidden-Size/Layer-Anzahl.
+- Trainings-Skript mit Train/Val-Split, Loss-Reporting und Speicherung der Gewichte.
+
+## Installation
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+## Datenerwartung
+Eine CSV-Datei mit mindestens zwei Spalten:
+- `date`: Zeitstempel oder Datum (wird per `pandas` geparst)
+- `close`: Schlusskurs oder Preiswert
+
+Die Reihenfolge der Zeilen ist egal, das Skript sortiert automatisch nach Datum.
+
+## Training starten
+```bash
+python -m stock_model.train path/zum/daten.csv \
+  --window 60 \
+  --batch-size 128 \
+  --epochs 30 \
+  --lr 5e-4 \
+  --hidden-size 256 \
+  --layers 2 \
+  --dropout 0.2 \
+  --train-ratio 0.85 \
+  --output artifacts
+```
+Standardwerte sind im Skript hinterlegt, sodass Sie optional nur den CSV-Pfad angeben müssen.
+
+## Forecast-Oberfläche im Dark Mode
+Starte die moderne Web-Oberfläche, um Daten hochzuladen, ein Modell zu laden oder kurzfristig zu trainieren und sofort einen Forecast zu erzeugen:
+
+```bash
+streamlit run stock_model/app.py
+```
+
+Die App bietet:
+- Dark-Theme mit Plotly-Visualisierungen.
+- Upload von CSV-Daten sowie optional eines `.pt`-Checkpoints.
+- Wahl der Fenstergröße, Forecast-Horizont und Schnelltraining mit wenigen Epochen.
+- Anzeige der prognostizierten Renditen und fortgeschriebenen Preise.
+
+## Ergebnisse
+Nach dem Training wird ein Checkpoint unter `artifacts/return_lstm.pt` gespeichert, der sowohl die Modellgewichte als auch die wichtigsten Hyperparameter (inkl. Normalisierungs-Statistiken) enthält. Dieses Format kann mit PyTorch geladen und für Inferenz oder weiteres Feintuning verwendet werden.
+
+Viel Erfolg beim Experimentieren mit Ihren Kursdaten!

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+pandas>=2.0
+numpy>=1.24
+torch>=2.0
+streamlit>=1.33
+plotly>=5.20

--- a/stock_model/app.py
+++ b/stock_model/app.py
@@ -1,0 +1,209 @@
+"""Streamlit UI for training and forecasting stock prices with a dark theme."""
+from __future__ import annotations
+
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+from typing import Tuple
+
+import numpy as np
+import pandas as pd
+import plotly.express as px
+import streamlit as st
+import torch
+from torch.utils.data import DataLoader
+
+from .data import PriceWindowDataset, load_prices
+from .inference import denormalize_returns, iterative_forecast, load_model_from_checkpoint, project_prices
+from .model import ReturnLSTM
+
+
+def _persist_upload(upload) -> Path:
+    tmp = NamedTemporaryFile(delete=False)
+    tmp.write(upload.getbuffer())
+    tmp.flush()
+    return Path(tmp.name)
+
+
+def train_lightweight_model(
+    returns: np.ndarray,
+    window: int,
+    epochs: int,
+    lr: float,
+    hidden_size: int,
+    num_layers: int,
+    dropout: float,
+    device: str,
+) -> Tuple[ReturnLSTM, float]:
+    dataset = PriceWindowDataset(returns, window=window)
+    loader = DataLoader(dataset, batch_size=64, shuffle=True)
+
+    model = ReturnLSTM(hidden_size=hidden_size, num_layers=num_layers, dropout=dropout).to(device)
+    optimizer = torch.optim.Adam(model.parameters(), lr=lr)
+    criterion = torch.nn.MSELoss()
+
+    model.train()
+    last_loss = 0.0
+    for _ in range(epochs):
+        epoch_loss = 0.0
+        for features, target in loader:
+            features, target = features.to(device), target.to(device)
+            optimizer.zero_grad()
+            preds = model(features)
+            loss = criterion(preds, target)
+            loss.backward()
+            optimizer.step()
+            epoch_loss += loss.item() * features.size(0)
+        last_loss = epoch_loss / len(loader.dataset)
+    return model, last_loss
+
+
+def render_chart(prices: np.ndarray, forecast_prices: np.ndarray) -> None:
+    history = pd.DataFrame({"Index": range(len(prices)), "Preis": prices, "Typ": "Historie"})
+    forecast_index = range(len(prices), len(prices) + len(forecast_prices))
+    forecast_df = pd.DataFrame(
+        {"Index": list(forecast_index), "Preis": forecast_prices, "Typ": "Forecast"}
+    )
+    combined = pd.concat([history, forecast_df])
+    fig = px.line(combined, x="Index", y="Preis", color="Typ", markers=True)
+    fig.update_layout(
+        template="plotly_dark",
+        hovermode="x unified",
+        legend_title="",
+        margin=dict(l=10, r=10, t=40, b=10),
+    )
+    st.plotly_chart(fig, use_container_width=True)
+
+
+def render_predictions(denorm_returns: np.ndarray, price_projection: np.ndarray) -> None:
+    next_return = denorm_returns[0] if len(denorm_returns) else 0.0
+    next_price = price_projection[0] if len(price_projection) else np.nan
+    st.metric("Nächste Rendite", f"{next_return * 100:.2f}%")
+    st.metric("Prognostizierter Preis", f"{next_price:,.2f}")
+
+    preview = pd.DataFrame(
+        {
+            "Schritt": list(range(1, len(denorm_returns) + 1)),
+            "Rendite (%)": denorm_returns * 100,
+            "Preis": price_projection,
+        }
+    )
+    st.dataframe(preview, use_container_width=True)
+
+
+def main() -> None:
+    st.set_page_config(page_title="Stock Forecaster", page_icon="📈", layout="wide")
+    st.title("📈 Dunkle KI-Oberfläche für Forecasting")
+    st.markdown(
+        """
+        Lade deine Kursdaten hoch, wähle optional ein trainiertes Modell und lasse die KI
+        einen mehrstufigen Forecast erstellen. Die Oberfläche ist für einen dunklen Modus optimiert.
+        """
+    )
+    st.markdown(
+        """
+        <style>
+        .stApp {
+            background: radial-gradient(circle at 10% 20%, rgba(56, 189, 248, 0.12), transparent 25%),
+                        radial-gradient(circle at 80% 0%, rgba(168, 85, 247, 0.12), transparent 25%),
+                        #0b1220;
+            color: #e5e7eb;
+        }
+        .block-container {
+            padding-top: 1.5rem;
+        }
+        .stDataFrame, .stMetric {
+            background-color: rgba(255, 255, 255, 0.03);
+            border-radius: 12px;
+            padding: 8px;
+        }
+        </style>
+        """,
+        unsafe_allow_html=True,
+    )
+
+    st.sidebar.header("Steuerung")
+    forecast_steps = st.sidebar.slider("Forecast-Schritte", min_value=1, max_value=14, value=3)
+    window = st.sidebar.slider("Fenstergröße", min_value=10, max_value=120, value=30, step=5)
+    date_col = st.sidebar.text_input("Datumsspalte", value="date")
+    price_col = st.sidebar.text_input("Preisspalte", value="close")
+
+    st.sidebar.subheader("Optional: Schnelltraining")
+    enable_training = st.sidebar.checkbox("Direkt in der App trainieren, wenn kein Checkpoint geladen ist")
+    train_epochs = st.sidebar.slider("Epochen", 1, 25, 5)
+    lr = st.sidebar.number_input("Lernrate", min_value=1e-5, max_value=1e-1, value=1e-3, format="%e")
+    hidden_size = st.sidebar.slider("Hidden Size", 32, 512, 128, step=32)
+    num_layers = st.sidebar.slider("LSTM Layer", 1, 4, 2)
+    dropout = st.sidebar.slider("Dropout", 0.0, 0.7, 0.1, step=0.05)
+
+    uploaded_csv = st.file_uploader("CSV mit Kursdaten", type=["csv"])
+    checkpoint_upload = st.file_uploader("Trainiertes Modell (.pt oder .pth)", type=["pt", "pth"])
+
+    if uploaded_csv is None:
+        st.info("Bitte lade eine CSV-Datei hoch, die mindestens `date` und `close` enthält.")
+        return
+
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    uploaded_csv.seek(0)
+    price_data = load_prices(uploaded_csv, date_col=date_col, price_col=price_col)
+    uploaded_csv.seek(0)
+
+    st.subheader("Datenvorschau")
+    df_preview = pd.read_csv(uploaded_csv)
+    st.dataframe(df_preview.head(), use_container_width=True)
+    uploaded_csv.seek(0)
+
+    st.subheader("Historische Preise")
+    render_chart(price_data.prices, np.array([]))
+
+    if st.button("Forecast berechnen"):
+        if checkpoint_upload is not None:
+            checkpoint_path = _persist_upload(checkpoint_upload)
+            model, hyper = load_model_from_checkpoint(checkpoint_path)
+            window = int(hyper.get("window", window))
+            mean = float(hyper.get("mean", price_data.mean))
+            std = float(hyper.get("std", price_data.std) or 1.0)
+            uploaded_csv.seek(0)
+            price_data = load_prices(
+                uploaded_csv, date_col=date_col, price_col=price_col, normalize=True, normalize_stats=(mean, std)
+            )
+        elif enable_training:
+            try:
+                model, last_loss = train_lightweight_model(
+                    price_data.returns,
+                    window=window,
+                    epochs=train_epochs,
+                    lr=lr,
+                    hidden_size=hidden_size,
+                    num_layers=num_layers,
+                    dropout=dropout,
+                    device=device,
+                )
+            except ValueError as exc:
+                st.error(str(exc))
+                return
+            mean, std = price_data.mean, price_data.std
+            st.toast(f"Training abgeschlossen (Loss ~ {last_loss:.4f})", icon="✅")
+        else:
+            st.warning("Lade einen Checkpoint oder aktiviere das Schnelltraining, um einen Forecast zu starten.")
+            return
+
+        try:
+            normalized_preds = iterative_forecast(
+                price_data.returns, model, window=window, steps=forecast_steps, device=device
+            )
+        except ValueError as exc:
+            st.error(str(exc))
+            return
+        denorm_preds = denormalize_returns(normalized_preds, mean=mean, std=std)
+        price_projection = project_prices(price_data.prices[-1], denorm_preds)
+
+        st.subheader("Forecast")
+        cols = st.columns([1, 2])
+        with cols[0]:
+            render_predictions(denorm_preds, price_projection)
+        with cols[1]:
+            render_chart(price_data.prices, price_projection)
+
+
+if __name__ == "__main__":
+    main()

--- a/stock_model/data.py
+++ b/stock_model/data.py
@@ -1,0 +1,83 @@
+"""Utilities for loading and preparing stock price data for sequence models."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import IO, Iterable, Tuple
+
+import numpy as np
+import pandas as pd
+import torch
+from torch.utils.data import Dataset
+
+
+@dataclass
+class PriceData:
+    """Container for price data and derived returns."""
+
+    prices: np.ndarray
+    returns: np.ndarray
+    mean: float
+    std: float
+
+
+def load_prices(
+    csv_path: Path | str | IO[str] | IO[bytes],
+    date_col: str = "date",
+    price_col: str = "close",
+    normalize: bool = True,
+    normalize_stats: Tuple[float, float] | None = None,
+) -> PriceData:
+    """Load stock prices from a CSV file.
+
+    The CSV must include a date column (parseable by pandas) and a price column.
+    Data are sorted by date to ensure chronological order. Returns are computed as
+    percentage change, optionally normalized to zero mean and unit variance.
+    """
+
+    df = pd.read_csv(csv_path)
+    df[date_col] = pd.to_datetime(df[date_col])
+    df = df.sort_values(date_col)
+
+    prices = df[price_col].astype(float).to_numpy()
+    raw_returns = np.diff(prices) / prices[:-1]
+
+    mean: float
+    std: float
+    if normalize:
+        if normalize_stats is not None:
+            mean, std = normalize_stats
+        else:
+            mean = float(raw_returns.mean())
+            std = float(raw_returns.std() or 1.0)
+        returns = (raw_returns - mean) / std
+    else:
+        returns = raw_returns
+        mean = float(raw_returns.mean())
+        std = float(raw_returns.std() or 1.0)
+
+    return PriceData(prices=prices, returns=returns, mean=mean, std=std)
+
+
+class PriceWindowDataset(Dataset[Tuple[torch.Tensor, torch.Tensor]]):
+    """Sequence dataset that predicts the next return from previous returns."""
+
+    def __init__(self, returns: Iterable[float], window: int = 30) -> None:
+        values = np.array(list(returns), dtype=np.float32)
+        if len(values) <= window:
+            raise ValueError("Not enough data to build any windows")
+        self.features = []
+        self.targets = []
+        for start in range(len(values) - window):
+            end = start + window
+            self.features.append(values[start:end])
+            self.targets.append(values[end])
+        self.features = np.stack(self.features)
+        self.targets = np.stack(self.targets)
+
+    def __len__(self) -> int:  # noqa: D401
+        return len(self.features)
+
+    def __getitem__(self, idx: int) -> Tuple[torch.Tensor, torch.Tensor]:  # noqa: D401
+        feature = torch.from_numpy(self.features[idx]).unsqueeze(-1)
+        target = torch.tensor(self.targets[idx], dtype=torch.float32)
+        return feature, target

--- a/stock_model/inference.py
+++ b/stock_model/inference.py
@@ -1,0 +1,94 @@
+"""Inference helpers for return forecasting and price projection."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable, Tuple
+
+import numpy as np
+import torch
+
+from .data import PriceData, load_prices
+from .model import ReturnLSTM
+
+
+def load_model_from_checkpoint(checkpoint_path: Path | str) -> Tuple[ReturnLSTM, dict]:
+    """Load a trained :class:`ReturnLSTM` and its hyperparameters."""
+
+    checkpoint = torch.load(checkpoint_path, map_location="cpu")
+    hyperparameters = checkpoint.get("hyperparameters", {})
+    model = ReturnLSTM(
+        input_dim=1,
+        hidden_size=hyperparameters.get("hidden_size", 64),
+        num_layers=hyperparameters.get("num_layers", 2),
+        dropout=hyperparameters.get("dropout", 0.1),
+    )
+    model.load_state_dict(checkpoint["model_state_dict"])
+    model.eval()
+    return model, hyperparameters
+
+
+def iterative_forecast(
+    returns: Iterable[float],
+    model: ReturnLSTM,
+    window: int,
+    steps: int = 1,
+    device: str | None = None,
+) -> np.ndarray:
+    """Generate ``steps`` normalized return forecasts by feeding back predictions."""
+
+    values = np.asarray(list(returns), dtype=np.float32)
+    if len(values) < window:
+        raise ValueError("Not enough data to build a forecast window")
+
+    model_device = device or ("cuda" if torch.cuda.is_available() else "cpu")
+    model = model.to(model_device)
+
+    current = torch.from_numpy(values[-window:]).unsqueeze(0).unsqueeze(-1).to(model_device)
+    predictions = []
+
+    model.eval()
+    for _ in range(steps):
+        with torch.no_grad():
+            pred = model(current).squeeze().item()
+        predictions.append(pred)
+        next_val = torch.tensor([[pred]], device=model_device)
+        current = torch.cat([current.squeeze(0), next_val], dim=0)[-window:].unsqueeze(0)
+
+    return np.array(predictions, dtype=np.float32)
+
+
+def denormalize_returns(predictions: Iterable[float], mean: float, std: float) -> np.ndarray:
+    """Convert normalized return predictions back into percentage returns."""
+
+    return np.array(predictions, dtype=np.float32) * std + mean
+
+
+def project_prices(last_price: float, returns: Iterable[float]) -> np.ndarray:
+    """Compute price levels from a starting price and predicted returns."""
+
+    price = float(last_price)
+    prices = []
+    for ret in returns:
+        price *= 1 + ret
+        prices.append(price)
+    return np.array(prices, dtype=np.float32)
+
+
+def forecast_from_csv(
+    csv_path: Path | str,
+    checkpoint_path: Path | str,
+    steps: int = 1,
+    device: str | None = None,
+) -> Tuple[np.ndarray, np.ndarray, PriceData]:
+    """Load data and checkpoint to forecast normalized returns and prices."""
+
+    model, hyperparameters = load_model_from_checkpoint(checkpoint_path)
+    window = int(hyperparameters.get("window", 30))
+    mean = float(hyperparameters.get("mean", 0.0))
+    std = float(hyperparameters.get("std", 1.0) or 1.0)
+
+    price_data = load_prices(csv_path, normalize=True, normalize_stats=(mean, std))
+    normalized_preds = iterative_forecast(price_data.returns, model, window=window, steps=steps, device=device)
+    denorm_preds = denormalize_returns(normalized_preds, mean=mean, std=std)
+    price_projection = project_prices(price_data.prices[-1], denorm_preds)
+    return normalized_preds, price_projection, price_data

--- a/stock_model/model.py
+++ b/stock_model/model.py
@@ -1,0 +1,38 @@
+"""Neural network model definitions for forecasting returns."""
+from __future__ import annotations
+
+import torch
+from torch import nn
+
+
+class ReturnLSTM(nn.Module):
+    """Predicts the next return based on a window of past returns."""
+
+    def __init__(
+        self,
+        input_dim: int = 1,
+        hidden_size: int = 64,
+        num_layers: int = 2,
+        dropout: float = 0.1,
+    ) -> None:
+        super().__init__()
+        self.lstm = nn.LSTM(
+            input_size=input_dim,
+            hidden_size=hidden_size,
+            num_layers=num_layers,
+            batch_first=True,
+            dropout=dropout if num_layers > 1 else 0.0,
+        )
+        self.head = nn.Sequential(
+            nn.LayerNorm(hidden_size),
+            nn.Linear(hidden_size, hidden_size // 2),
+            nn.ReLU(),
+            nn.Linear(hidden_size // 2, 1),
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:  # noqa: D401
+        # x: [batch, seq, features]
+        output, _ = self.lstm(x)
+        last_hidden = output[:, -1, :]
+        prediction = self.head(last_hidden).squeeze(-1)
+        return prediction

--- a/stock_model/train.py
+++ b/stock_model/train.py
@@ -1,0 +1,128 @@
+"""Training script for the return forecasting model."""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Tuple
+
+import torch
+from torch.utils.data import DataLoader, random_split
+
+from .data import PriceWindowDataset, load_prices
+from .model import ReturnLSTM
+
+
+def split_dataset(dataset: PriceWindowDataset, train_ratio: float) -> Tuple[PriceWindowDataset, PriceWindowDataset]:
+    train_len = int(len(dataset) * train_ratio)
+    val_len = len(dataset) - train_len
+    return random_split(dataset, [train_len, val_len], generator=torch.Generator().manual_seed(42))
+
+
+def train(
+    csv_path: Path,
+    output_dir: Path,
+    window: int = 30,
+    batch_size: int = 64,
+    epochs: int = 20,
+    lr: float = 1e-3,
+    hidden_size: int = 128,
+    num_layers: int = 2,
+    dropout: float = 0.1,
+    train_ratio: float = 0.8,
+    device: str | None = None,
+) -> None:
+    data = load_prices(csv_path)
+    dataset = PriceWindowDataset(data.returns, window=window)
+    train_set, val_set = split_dataset(dataset, train_ratio)
+
+    train_loader = DataLoader(train_set, batch_size=batch_size, shuffle=True)
+    val_loader = DataLoader(val_set, batch_size=batch_size)
+
+    model = ReturnLSTM(hidden_size=hidden_size, num_layers=num_layers, dropout=dropout)
+    optimizer = torch.optim.Adam(model.parameters(), lr=lr)
+    criterion = torch.nn.MSELoss()
+
+    model_device = device or ("cuda" if torch.cuda.is_available() else "cpu")
+    model.to(model_device)
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    for epoch in range(1, epochs + 1):
+        model.train()
+        total_loss = 0.0
+        for features, target in train_loader:
+            features, target = features.to(model_device), target.to(model_device)
+            optimizer.zero_grad()
+            preds = model(features)
+            loss = criterion(preds, target)
+            loss.backward()
+            optimizer.step()
+            total_loss += loss.item() * features.size(0)
+        train_loss = total_loss / len(train_loader.dataset)
+
+        model.eval()
+        val_loss = 0.0
+        with torch.no_grad():
+            for features, target in val_loader:
+                features, target = features.to(model_device), target.to(model_device)
+                preds = model(features)
+                loss = criterion(preds, target)
+                val_loss += loss.item() * features.size(0)
+        val_loss = val_loss / len(val_loader.dataset)
+
+        print(f"Epoch {epoch:03d} | train_loss={train_loss:.6f} | val_loss={val_loss:.6f}")
+
+    model_path = output_dir / "return_lstm.pt"
+    torch.save(
+        {
+            "model_state_dict": model.state_dict(),
+            "hyperparameters": {
+                "window": window,
+                "hidden_size": hidden_size,
+                "num_layers": num_layers,
+                "dropout": dropout,
+                "train_ratio": train_ratio,
+                "mean": data.mean,
+                "std": data.std,
+            },
+        },
+        model_path,
+    )
+    print(f"Saved model to {model_path}")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("csv_path", type=Path, help="Path to CSV file containing prices")
+    parser.add_argument("--output", type=Path, default=Path("artifacts"), help="Directory to save model checkpoints")
+    parser.add_argument("--window", type=int, default=30, help="Number of past returns per sample")
+    parser.add_argument("--batch-size", type=int, default=64, help="Training batch size")
+    parser.add_argument("--epochs", type=int, default=20, help="Number of training epochs")
+    parser.add_argument("--lr", type=float, default=1e-3, help="Learning rate")
+    parser.add_argument("--hidden-size", type=int, default=128, help="LSTM hidden size")
+    parser.add_argument("--layers", type=int, default=2, help="Number of LSTM layers")
+    parser.add_argument("--dropout", type=float, default=0.1, help="Dropout between LSTM layers")
+    parser.add_argument("--train-ratio", type=float, default=0.8, help="Ratio of samples for training")
+    parser.add_argument("--device", type=str, default=None, help="Optional device override (cpu or cuda)")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    train(
+        csv_path=args.csv_path,
+        output_dir=args.output,
+        window=args.window,
+        batch_size=args.batch_size,
+        epochs=args.epochs,
+        lr=args.lr,
+        hidden_size=args.hidden_size,
+        num_layers=args.layers,
+        dropout=args.dropout,
+        train_ratio=args.train_ratio,
+        device=args.device,
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a dark-mode Streamlit interface that uploads data/checkpoints, supports quick training, and visualizes forecasts
- add inference utilities and save normalization stats in checkpoints for consistent predictions
- update dependencies and theme configuration for the new UI

## Testing
- python -m compileall stock_model

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69261a7d1948832c8c465691060ca155)